### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 on: [push]
 
 name: ci
+permissions:
+  contents: read
 
 jobs:
   build_and_test:
@@ -30,6 +32,8 @@ jobs:
     needs: build_and_test
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ${{ matrix.config.os }}
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/jiep/primos-adri/security/code-scanning/2](https://github.com/jiep/primos-adri/security/code-scanning/2)

To fix the problem, we should add an explicit `permissions` block to the workflow. The best practice is to set the most restrictive permissions at the workflow level (e.g., `contents: read`), and then override them at the job level if a job requires broader permissions. In this case, the `build_and_test` job only needs read access to the repository contents, while the `deploy` job, which creates releases, needs `contents: write`. Therefore:

- Add `permissions: contents: read` at the top level of the workflow (applies to all jobs by default).
- Add `permissions: contents: write` to the `deploy` job to allow it to upload release assets.

No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
